### PR TITLE
답변 다이어리 API를 추가합니다.

### DIFF
--- a/routers/answers/answers.ctroller.ts
+++ b/routers/answers/answers.ctroller.ts
@@ -226,7 +226,7 @@ const diary: RequestResponseNext = async (req, res, next) => {
     const direction = parseInt(req.query.direction || 0, 10);
     const userId = req.user!.id;
     const answers = lastId ? await getAnswersDiaryByLastId({ userId, lastId, limit, direction })
-      : await await getAnswersDiary({ userId, limit: limit ? limit : 100 });
+      : await await getAnswersDiary({ userId, limit });
     res.json(response({ data: { lastId, limit, direction, answers } }));
   } catch (error) {
     console.log(error.message);

--- a/routers/answers/answers.ctroller.ts
+++ b/routers/answers/answers.ctroller.ts
@@ -14,6 +14,8 @@ import {
   getMonthAnswers,
   getRecentAnswers,
   updateAnswer,
+  getAnswersDiary,
+  getAnswersDiaryByLastId,
 } from './answers.repository';
 import { getNo, getPartNumber, getSetDate, hasSetDate, hasSixParsAndNotToday } from './answers.service';
 import File from '../../models/file';
@@ -217,6 +219,19 @@ const destroy: RequestResponseNext = async (req, res, next) => {
   }
 };
 
+const diary: RequestResponseNext = async (req, res, next) => {
+  try {
+    const { lastId, limit, direction } = req.query;
+    const userId = req.user!.id;
+    const answers = lastId ? await getAnswersDiaryByLastId({ userId, lastId, limit: limit ? limit : 100, direction: direction ? direction : 0 })
+      : await await getAnswersDiary({ userId, limit: limit ? limit : 100 });
+    res.json(response({ data: { lastId, limit, direction, answers } }));
+  } catch (error) {
+    console.log(error.message);
+    res.status(500).json(response({ status: 500, message: error.message }));
+  }
+};
+
 export default {
   week,
   month,
@@ -227,4 +242,5 @@ export default {
   create,
   update,
   destroy,
+  diary,
 };

--- a/routers/answers/answers.ctroller.ts
+++ b/routers/answers/answers.ctroller.ts
@@ -221,7 +221,9 @@ const destroy: RequestResponseNext = async (req, res, next) => {
 
 const diary: RequestResponseNext = async (req, res, next) => {
   try {
-    const { lastId, limit, direction } = req.query;
+    const lastId = parseInt(req.query.lastId, 10);
+    const limit = parseInt(req.query.limit, 10);
+    const direction = parseInt(req.query.direction, 10);
     const userId = req.user!.id;
     const answers = lastId ? await getAnswersDiaryByLastId({ userId, lastId, limit: limit ? limit : 100, direction: direction ? direction : 0 })
       : await await getAnswersDiary({ userId, limit: limit ? limit : 100 });

--- a/routers/answers/answers.ctroller.ts
+++ b/routers/answers/answers.ctroller.ts
@@ -222,10 +222,10 @@ const destroy: RequestResponseNext = async (req, res, next) => {
 const diary: RequestResponseNext = async (req, res, next) => {
   try {
     const lastId = parseInt(req.query.lastId, 10);
-    const limit = parseInt(req.query.limit, 10);
-    const direction = parseInt(req.query.direction, 10);
+    const limit = parseInt(req.query.limit || 100, 10);
+    const direction = parseInt(req.query.direction || 0, 10);
     const userId = req.user!.id;
-    const answers = lastId ? await getAnswersDiaryByLastId({ userId, lastId, limit: limit ? limit : 100, direction: direction ? direction : 0 })
+    const answers = lastId ? await getAnswersDiaryByLastId({ userId, lastId, limit, direction })
       : await await getAnswersDiary({ userId, limit: limit ? limit : 100 });
     res.json(response({ data: { lastId, limit, direction, answers } }));
   } catch (error) {

--- a/routers/answers/answers.repository.ts
+++ b/routers/answers/answers.repository.ts
@@ -139,3 +139,34 @@ export const getAnswersByuserIdAndDateRange = async ({
     include: [{ all: true }],
   });
 };
+
+export const getAnswersDiary = async ({ userId, limit }: { userId: number; limit: number }): Promise<Answer[]> => {
+  return db.Answer.findAll({
+    where: {
+      userId,
+    },
+    limit: limit,
+    order: [
+      ['id', 'DESC'],
+    ],
+    include: [{ all: true }],
+  });
+};
+
+export const getAnswersDiaryByLastId = async ({ userId, lastId, limit, direction }: { userId: number; lastId: number; limit: number; direction: number }): Promise<Answer[]> => {
+  const directionSymbol = direction === 0 ? Op.lte : Op.gte;
+  console.log(direction);
+  return db.Answer.findAll({
+    where: {
+      id: {
+        [directionSymbol]: lastId,
+      },
+      userId,
+    },
+    limit: limit,
+    order: [
+      ['id', 'DESC'],
+    ],
+    include: [{ all: true }],
+  });
+};

--- a/routers/answers/answers.repository.ts
+++ b/routers/answers/answers.repository.ts
@@ -155,7 +155,6 @@ export const getAnswersDiary = async ({ userId, limit }: { userId: number; limit
 
 export const getAnswersDiaryByLastId = async ({ userId, lastId, limit, direction }: { userId: number; lastId: number; limit: number; direction: number }): Promise<Answer[]> => {
   const directionSymbol = direction === 0 ? Op.lt : Op.gt;
-  console.log(direction);
   return db.Answer.findAll({
     where: {
       id: {

--- a/routers/answers/answers.repository.ts
+++ b/routers/answers/answers.repository.ts
@@ -154,7 +154,7 @@ export const getAnswersDiary = async ({ userId, limit }: { userId: number; limit
 };
 
 export const getAnswersDiaryByLastId = async ({ userId, lastId, limit, direction }: { userId: number; lastId: number; limit: number; direction: number }): Promise<Answer[]> => {
-  const directionSymbol = direction === 0 ? Op.lte : Op.gte;
+  const directionSymbol = direction === 0 ? Op.lt : Op.gt;
   console.log(direction);
   return db.Answer.findAll({
     where: {

--- a/routers/answers/index.ts
+++ b/routers/answers/index.ts
@@ -12,6 +12,7 @@ import {
 
 const router = Router();
 
+router.get('/diary', checkToken, answersController.diary);
 router.get('/week', checkToken, answersController.week);
 router.get('/list', checkToken, answersController.list);
 router.get('/list/:id', checkToken,checkId, answersController.listId);

--- a/swagger/path/answers.swagger.js
+++ b/swagger/path/answers.swagger.js
@@ -770,13 +770,13 @@ module.exports = {
               "status": 200,
               "message": "",
               "data": {
-                "lastId": "3420",
-                "direction": "1",
+                "lastId": 3420,
+                "direction": 1,
                 "answers": [
                   {
                     "id": 3788,
                     "imageUrl": null,
-                    "content": "ㅇ\nㅇ\nㅇ\nㅇ\nㅇ\nㅇ\nㅇ\nㅇ\nㅇ\nㅇ\nㅇ\nㅇ\nㅇㅇ\nㅇ\nㅇ\nㅇ\nㅇ\nㅇ\nㅇ\nㅇ\nㅇ\nㅇ\nㅇ\nㅇ\nㅇ\nㅇ\nㅇ\n",
+                    "content": "",
                     "date": "2021-01-17",
                     "setDate": "2021-01-17",
                     "no": 2,
@@ -806,13 +806,13 @@ module.exports = {
                     "user": {
                       "id": 119,
                       "birthday": "미입력",
-                      "email": "9pxx2sqy8k@privaterelay.appleid.com",
-                      "name": "11111111",
+                      "email": "",
+                      "name": "",
                       "gender": "미입력",
                       "refreshDate": null,
                       "refreshToken": null,
                       "mission": "{\"date\":\"2021-01-17\",\"missions\":[{\"id\":3,\"title\":\"지금 떠오르는 내가 좋아하는 것 5가지만 이야기 해보아요.\",\"isContent\":true,\"isImage\":false,\"cycle\":14,\"createdAt\":\"2020-04-01 14:14:17\",\"updatedAt\":\"2020-04-01 14:14:17\"},{\"id\":7,\"title\":\"오늘 당신의 패션을 알려주세요!\",\"isContent\":true,\"isImage\":true,\"cycle\":3,\"createdAt\":\"2020-04-01 14:14:17\",\"updatedAt\":\"2020-04-01 14:14:17\"},{\"id\":24,\"title\":\"요즘 삶의 낙이 무엇인가요?\",\"isContent\":true,\"isImage\":false,\"cycle\":20,\"createdAt\":\"2020-04-01 14:14:17\",\"updatedAt\":\"2020-04-01 14:14:17\"}]}",
-                      "snsId": "000252.cd6ccffeaea547f6b2d0215e7d7c4f5a.0437",
+                      "snsId": "1",
                       "snsType": "apple",
                       "createdAt": "2020-04-17 13:49:35",
                       "updatedAt": "2021-01-17 22:21:54"
@@ -821,7 +821,7 @@ module.exports = {
                   {
                     "id": 3420,
                     "imageUrl": null,
-                    "content": "❤️❤️",
+                    "content": "",
                     "date": "2020-12-28",
                     "setDate": "2020-04-17",
                     "no": 1,
@@ -851,13 +851,13 @@ module.exports = {
                     "user": {
                       "id": 119,
                       "birthday": "미입력",
-                      "email": "9pxx2sqy8k@privaterelay.appleid.com",
-                      "name": "11111111",
+                      "email": "@privaterelay.appleid.com",
+                      "name": "",
                       "gender": "미입력",
                       "refreshDate": null,
                       "refreshToken": null,
                       "mission": "{\"date\":\"2021-01-17\",\"missions\":[{\"id\":3,\"title\":\"지금 떠오르는 내가 좋아하는 것 5가지만 이야기 해보아요.\",\"isContent\":true,\"isImage\":false,\"cycle\":14,\"createdAt\":\"2020-04-01 14:14:17\",\"updatedAt\":\"2020-04-01 14:14:17\"},{\"id\":7,\"title\":\"오늘 당신의 패션을 알려주세요!\",\"isContent\":true,\"isImage\":true,\"cycle\":3,\"createdAt\":\"2020-04-01 14:14:17\",\"updatedAt\":\"2020-04-01 14:14:17\"},{\"id\":24,\"title\":\"요즘 삶의 낙이 무엇인가요?\",\"isContent\":true,\"isImage\":false,\"cycle\":20,\"createdAt\":\"2020-04-01 14:14:17\",\"updatedAt\":\"2020-04-01 14:14:17\"}]}",
-                      "snsId": "000252.cd6ccffeaea547f6b2d0215e7d7c4f5a.0437",
+                      "snsId": "1",
                       "snsType": "apple",
                       "createdAt": "2020-04-17 13:49:35",
                       "updatedAt": "2021-01-17 22:21:54"

--- a/swagger/path/answers.swagger.js
+++ b/swagger/path/answers.swagger.js
@@ -725,4 +725,150 @@ module.exports = {
       },
     },
   },
+  '/api/v1/answers/diary': {
+    get: {
+      tags: ['answers'],
+      summary: '일기 형식으로 답변 조회',
+      produces: ['application/json'],
+      parameters: [
+        {
+          name: 'Authorization',
+          in: 'header',
+          type: 'string',
+          description: 'API 인증 키',
+          default:
+            'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyIjp7ImlkIjoxLCJiaXJ0aGRheSI6IjE5OTctMDEtMTYiLCJlbWFpbCI6Inl1Y2hvY29waWVAZ21haWwuY29tIiwibmFtZSI6IuycoOyglSIsImdlbmRlciI6IuyXrCIsInJlZnJlc2hEYXRlIjpudWxsLCJyZWZyZXNoVG9rZW4iOm51bGwsIm1pc3Npb24iOm51bGwsInNuc0lkIjoiMSIsInNuc1R5cGUiOiJnb29nbGUiLCJjcmVhdGVkQXQiOiIyMDIwLTAxLTAzVDE3OjM0OjM3LjAwMFoiLCJ1cGRhdGVkQXQiOiIyMDIwLTAxLTAzVDE3OjM0OjM3LjAwMFoifSwiaWF0IjoxNTc4MDcyODc5LCJleHAiOjE1Nzg2Nzc2Nzl9.4jBy8Wrj9IukT2H2OU0UdqQjehNXMGio1KAd01z3DvE',
+          required: true,
+        },
+        {
+          name: 'lastId',
+          in: 'query',
+          type: 'integer',
+          description: '기준이 되는 답변 Id, default : 최근 Id',
+          required: false,
+        },
+        {
+          name: 'limit',
+          in: 'query',
+          type: 'integer',
+          description: '조회할 갯수, default : 100',
+          required: false,
+        },
+        {
+          name: 'direction',
+          in: 'query',
+          type: 'integer',
+          description: '0 : 과거 데이터, 1 : 최신 데이터 방향으로 조회, default : 0',
+          required: false,
+        },
+      ],
+      responses: {
+        200: {
+          schema: {
+            type: 'object',
+            example: {
+              "status": 200,
+              "message": "",
+              "data": {
+                "lastId": "3420",
+                "direction": "1",
+                "answers": [
+                  {
+                    "id": 3788,
+                    "imageUrl": null,
+                    "content": "ㅇ\nㅇ\nㅇ\nㅇ\nㅇ\nㅇ\nㅇ\nㅇ\nㅇ\nㅇ\nㅇ\nㅇ\nㅇㅇ\nㅇ\nㅇ\nㅇ\nㅇ\nㅇ\nㅇ\nㅇ\nㅇ\nㅇ\nㅇ\nㅇ\nㅇ\nㅇ\nㅇ\n",
+                    "date": "2021-01-17",
+                    "setDate": "2021-01-17",
+                    "no": 2,
+                    "createdAt": "2021-01-17 22:23:39",
+                    "updatedAt": "2021-01-17 22:23:39",
+                    "missionId": 3,
+                    "fileId": 37,
+                    "userId": 119,
+                    "mission": {
+                      "id": 3,
+                      "title": "지금 떠오르는 내가 좋아하는 것 5가지만 이야기 해보아요.",
+                      "isContent": true,
+                      "isImage": false,
+                      "cycle": 14,
+                      "createdAt": "2020-04-01 14:14:17",
+                      "updatedAt": "2020-04-01 14:14:17"
+                    },
+                    "file": {
+                      "id": 37,
+                      "cardUrl": "https://moti-media.s3.ap-northeast-2.amazonaws.com/parts/1-7.pdf",
+                      "cardSvgUrl": "https://moti-media.s3.ap-northeast-2.amazonaws.com/parts/1-7.svg",
+                      "cardPngUrl": "https://moti-media.s3.ap-northeast-2.amazonaws.com/parts/1-7.png",
+                      "part": 1,
+                      "createdAt": "2020-04-01 15:53:10",
+                      "updatedAt": "2020-09-07 22:08:34"
+                    },
+                    "user": {
+                      "id": 119,
+                      "birthday": "미입력",
+                      "email": "9pxx2sqy8k@privaterelay.appleid.com",
+                      "name": "11111111",
+                      "gender": "미입력",
+                      "refreshDate": null,
+                      "refreshToken": null,
+                      "mission": "{\"date\":\"2021-01-17\",\"missions\":[{\"id\":3,\"title\":\"지금 떠오르는 내가 좋아하는 것 5가지만 이야기 해보아요.\",\"isContent\":true,\"isImage\":false,\"cycle\":14,\"createdAt\":\"2020-04-01 14:14:17\",\"updatedAt\":\"2020-04-01 14:14:17\"},{\"id\":7,\"title\":\"오늘 당신의 패션을 알려주세요!\",\"isContent\":true,\"isImage\":true,\"cycle\":3,\"createdAt\":\"2020-04-01 14:14:17\",\"updatedAt\":\"2020-04-01 14:14:17\"},{\"id\":24,\"title\":\"요즘 삶의 낙이 무엇인가요?\",\"isContent\":true,\"isImage\":false,\"cycle\":20,\"createdAt\":\"2020-04-01 14:14:17\",\"updatedAt\":\"2020-04-01 14:14:17\"}]}",
+                      "snsId": "000252.cd6ccffeaea547f6b2d0215e7d7c4f5a.0437",
+                      "snsType": "apple",
+                      "createdAt": "2020-04-17 13:49:35",
+                      "updatedAt": "2021-01-17 22:21:54"
+                    }
+                  },
+                  {
+                    "id": 3420,
+                    "imageUrl": null,
+                    "content": "❤️❤️",
+                    "date": "2020-12-28",
+                    "setDate": "2020-04-17",
+                    "no": 1,
+                    "createdAt": "2020-12-28 18:11:34",
+                    "updatedAt": "2020-12-28 18:11:34",
+                    "missionId": 9,
+                    "fileId": 18,
+                    "userId": 119,
+                    "mission": {
+                      "id": 9,
+                      "title": "일주일간 치킨은 몇마리나 드셨나요?",
+                      "isContent": true,
+                      "isImage": false,
+                      "cycle": 90,
+                      "createdAt": "2020-04-01 14:14:17",
+                      "updatedAt": "2020-04-01 14:14:17"
+                    },
+                    "file": {
+                      "id": 18,
+                      "cardUrl": "https://moti-media.s3.ap-northeast-2.amazonaws.com/parts/6_3.pdf",
+                      "cardSvgUrl": "https://moti-media.s3.ap-northeast-2.amazonaws.com/parts/6_3.svg",
+                      "cardPngUrl": "https://moti-media.s3.ap-northeast-2.amazonaws.com/parts/6_3.png",
+                      "part": 6,
+                      "createdAt": "2020-04-01 15:51:24",
+                      "updatedAt": "2021-01-24 03:47:04"
+                    },
+                    "user": {
+                      "id": 119,
+                      "birthday": "미입력",
+                      "email": "9pxx2sqy8k@privaterelay.appleid.com",
+                      "name": "11111111",
+                      "gender": "미입력",
+                      "refreshDate": null,
+                      "refreshToken": null,
+                      "mission": "{\"date\":\"2021-01-17\",\"missions\":[{\"id\":3,\"title\":\"지금 떠오르는 내가 좋아하는 것 5가지만 이야기 해보아요.\",\"isContent\":true,\"isImage\":false,\"cycle\":14,\"createdAt\":\"2020-04-01 14:14:17\",\"updatedAt\":\"2020-04-01 14:14:17\"},{\"id\":7,\"title\":\"오늘 당신의 패션을 알려주세요!\",\"isContent\":true,\"isImage\":true,\"cycle\":3,\"createdAt\":\"2020-04-01 14:14:17\",\"updatedAt\":\"2020-04-01 14:14:17\"},{\"id\":24,\"title\":\"요즘 삶의 낙이 무엇인가요?\",\"isContent\":true,\"isImage\":false,\"cycle\":20,\"createdAt\":\"2020-04-01 14:14:17\",\"updatedAt\":\"2020-04-01 14:14:17\"}]}",
+                      "snsId": "000252.cd6ccffeaea547f6b2d0215e7d7c4f5a.0437",
+                      "snsType": "apple",
+                      "createdAt": "2020-04-17 13:49:35",
+                      "updatedAt": "2021-01-17 22:21:54"
+                    }
+                  },
+                ],
+              },
+            },
+          },
+        },
+      },
+    },
+  },
 };


### PR DESCRIPTION
## 작업 내용
1. 답변 다이어리 레포지토리에서 `getAnswersDiary`, `getAnswersDiaryByLastId` 함수 추가
2. 답변 컨트롤러에서 `diary` 핸들러 추가
3. 답변 라우팅에서 `/diary` GET 라우트 추가
4. 스웨거에 답변 다이어리 API 명세 추가

## 이슈 사항
라우팅을 맨 마지막에 넣었을 때, CheckId 미들웨어가 자동으로 삽입되는 현상이 있었습니다.